### PR TITLE
fix: make telegram notifications gracefully skip when secrets unavailable

### DIFF
--- a/telegram-notify.py
+++ b/telegram-notify.py
@@ -20,7 +20,9 @@ def main():
     chat_id = os.getenv("TELEGRAM_CHAT_ID")
 
     if not bot_token or not chat_id:
-        print("Warning: TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID not set - skipping notification")
+        print(
+            "Warning: TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID not set - skipping notification"
+        )
         sys.exit(0)
 
     url = f"https://api.telegram.org/bot{bot_token}/sendMessage"

--- a/telegram-notify.py
+++ b/telegram-notify.py
@@ -20,8 +20,8 @@ def main():
     chat_id = os.getenv("TELEGRAM_CHAT_ID")
 
     if not bot_token or not chat_id:
-        print("Error: TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID must be set")
-        sys.exit(1)
+        print("Warning: TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID not set - skipping notification")
+        sys.exit(0)
 
     url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
     payload = {


### PR DESCRIPTION
## Problem
Dependabot PRs cannot access repository secrets, causing CI failures in lint and blog steps that use the telegram-notify.py script.

## Solution
Change telegram-notify.py to exit with code 0 (success) instead of code 1 (failure) when TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID are missing. This allows Dependabot PRs to complete CI successfully by skipping the notification step instead of failing.

## Impact
- Fixes CI failures on Dependabot PRs in aa-dev-prod-watcher, redhat-ai-workflow, and other repos
- Notifications still work normally when secrets are available
- Dependabot PRs can now pass CI and be auto-merged

## Testing
Will monitor aa-dev-prod-watcher PR #79 and redhat-ai-workflow PRs #169, #170 after this merges.